### PR TITLE
Fixing packet bugs when receiving ids off Robots_Count range

### DIFF
--- a/src/sslworld.cpp
+++ b/src/sslworld.cpp
@@ -372,7 +372,7 @@ SSLWorld::SSLWorld(QGLWidget *parent, ConfigWidget *_cfg, RobotsFormation *form)
 int SSLWorld::robotIndex(unsigned int robot, int team)
 {
     if (robot >= cfg->Robots_Count())
-        return 0;
+        return -1;
     return robot + team * cfg->Robots_Count();
 }
 


### PR DESCRIPTION
### Identify the Bug
#4

### Description of the Change
When FIRASim received packets with an id out of range, it by default returned the identifier 0 as the robot that would assume the data sent by the command, causing control problems.

### Alternate Designs
N/A

### Possible Drawbacks
N/A

### Verification Process
I performed a test with 5 commands sent to robots with identifier 0 to 4 (simulating with 3 robots) and noticed that the bug was occurring due to packages for robots with identifier 3 and 4 being ignored and treated as if they were directed to the robot with identifier 0.
By modifying the function I noticed that the problem was solved as the return is now for an invalid identifier `-1`.

### Release Notes
N/A