### PR TITLE
fix: load robot/team configs correctly in Docker installs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN git clone https://github.com/jpfeltracco/vartypes.git . && \
     mkdir -p build && \
     cd build && \
     cmake .. && \
-    make -j"$(nproc)" && \
+    make && \
     make install && \
     ldconfig
 
@@ -46,8 +46,10 @@ COPY config/*.ini /usr/local/share/grsim/config/
 RUN mkdir -p build && \
     cd build && \
     cmake -DCMAKE_INSTALL_PREFIX=/usr/local .. && \
-    make -j"$(nproc)" && \
-    make install
+    make && \
+    make install && \
+    ldconfig
+
 
 FROM ubuntu:20.04
 ENV DEBIAN_FRONTEND=noninteractive \
@@ -59,7 +61,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libqt5opengl5 \
         libode8 \
         libprotobuf17 \
-        x11vnc xvfb \
+        xvfb \
+        x11vnc \
+        x11-utils \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=build /usr/local /usr/local

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,74 @@
+FROM ubuntu:20.04 AS build
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    ca-certificates \
+    build-essential \
+    cmake \
+    pkg-config \
+    qt5-default \
+    libqt5opengl5-dev \
+    libgl1-mesa-dev \
+    libglu1-mesa-dev \
+    libprotobuf-dev \
+    protobuf-compiler \
+    libode-dev \
+    libboost-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /vartypes
+RUN git clone https://github.com/jpfeltracco/vartypes.git . && \
+    git checkout 2d16e81b7995f25c5ba5e4bc31bf9a514ee4bc42 && \
+    mkdir -p build && \
+    cd build && \
+    cmake .. && \
+    make -j"$(nproc)" && \
+    make install && \
+    ldconfig
+
+WORKDIR /firasim
+COPY cmake /firasim/cmake
+COPY config /firasim/config
+COPY include /firasim/include
+COPY resources /firasim/resources
+COPY formation /firasim/formation
+COPY msg /firasim/msg
+COPY src /firasim/src
+COPY CMakeLists.txt README.md LICENSE.md INSTALL.md AUTHORS.md CHANGELOG.md /firasim/
+
+RUN mkdir -p /usr/local/share/firasim
+COPY firasim.xml /usr/local/share/firasim/grsim.xml
+
+RUN mkdir -p /usr/local/share/grsim/config
+COPY config/*.ini /usr/local/share/grsim/config/
+
+RUN mkdir -p build && \
+    cd build && \
+    cmake -DCMAKE_INSTALL_PREFIX=/usr/local .. && \
+    make -j"$(nproc)" && \
+    make install
+
+FROM ubuntu:20.04
+ENV DEBIAN_FRONTEND=noninteractive \
+    LD_LIBRARY_PATH=/lib:/usr/lib:/usr/local/lib
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        tini \
+        qt5-default \
+        libqt5opengl5 \
+        libode8 \
+        libprotobuf17 \
+        x11vnc xvfb \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=build /usr/local /usr/local
+
+RUN useradd -ms /bin/bash default
+COPY docker-entry.sh /docker-entry.sh
+RUN chmod 775 /docker-entry.sh
+
+EXPOSE 20011 30011 30012 10300 10301 10302 5900
+USER default
+WORKDIR /home/default
+ENTRYPOINT ["tini", "--", "/docker-entry.sh"]

--- a/docker-entry.sh
+++ b/docker-entry.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -e
+
+export QT_AUTO_SCREEN_SCALE_FACTOR=0
+export QT_ENABLE_HIGHDPI_SCALING=0
+export QT_SCALE_FACTOR=1
+export QT_SCREEN_SCALE_FACTORS=1
+export QT_FONT_DPI=96
+export XFT_DPI=96
+
+export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/tmp/runtime-default}"
+mkdir -p "$XDG_RUNTIME_DIR" || true
+chmod 700 "$XDG_RUNTIME_DIR" || true
+
+export HOME="${HOME:-/home/default}"
+if [[ ! -f "$HOME/.grsim.xml" ]]; then
+  cp /usr/local/share/firasim/grsim.xml "$HOME/.grsim.xml"
+  chmod 644 "$HOME/.grsim.xml" || true
+fi
+
+if [[ "$1" == "vnc" ]]; then
+  shift
+  echo "Launch in VNC mode"
+
+  : "${VNC_PASSWORD:=vncpassword}"
+  : "${VNC_GEOMETRY:=1280x1024}"
+
+  mkdir -p ~/.vnc
+  x11vnc -storepasswd "${VNC_PASSWORD}" ~/.vnc/passwd
+
+  export DISPLAY=:99
+  Xvfb :99 -screen 0 "${VNC_GEOMETRY}x24" -dpi 96 -ac +extension GLX +render -noreset &
+
+  /usr/local/bin/FIRASim "$@" &
+
+  exec x11vnc -forever -shared -usepw -display :99 -rfbport 5900 -noxdamage
+
+elif [[ -n "$DISPLAY" ]]; then
+  echo "Launch with host X11 display: $DISPLAY"
+  exec /usr/local/bin/FIRASim "$@"
+
+else
+  echo "Launch in offscreen mode (no DISPLAY)"
+  exec /usr/local/bin/FIRASim -platform offscreen "$@"
+fi

--- a/firasim.xml
+++ b/firasim.xml
@@ -1,0 +1,258 @@
+<?xml version="1.0" encoding="utf-8"?>
+<VarXML>
+	<Var name="Geometry" type="list">
+		<Var name="Game" type="list">
+			<Var name="Division" type="stringenum">
+				Division B
+				<Var name="0" type="string">
+					Division A
+				</Var>
+				<Var name="1" type="string">
+					Division B
+				</Var>
+			</Var>
+			<Var name="Robots Count" type="int" minval="" maxval="">
+				3
+			</Var>
+		</Var>
+		<Var name="Field" type="list">
+			<Var name="VSSS A" type="list">
+				<Var name="Line Thickness" type="double" minval="" maxval="">
+					0.003000
+				</Var>
+				<Var name="Length" type="double" minval="" maxval="">
+					2.200000
+				</Var>
+				<Var name="Width" type="double" minval="" maxval="">
+					1.800000
+				</Var>
+				<Var name="Radius" type="double" minval="" maxval="">
+					0.250000
+				</Var>
+				<Var name="Free Kick Distance From Defense Area" type="double" minval="" maxval="">
+					0.250000
+				</Var>
+				<Var name="Penalty width" type="double" minval="" maxval="">
+					0.500000
+				</Var>
+				<Var name="Penalty depth" type="double" minval="" maxval="">
+					0.150000
+				</Var>
+				<Var name="Penalty point" type="double" minval="" maxval="">
+					0.375000
+				</Var>
+				<Var name="Margin" type="double" minval="" maxval="">
+					0.300000
+				</Var>
+				<Var name="Referee margin" type="double" minval="" maxval="">
+					0.400000
+				</Var>
+				<Var name="Wall thickness" type="double" minval="" maxval="">
+					0.025000
+				</Var>
+				<Var name="Goal thickness" type="double" minval="" maxval="">
+					0.025000
+				</Var>
+				<Var name="Goal depth" type="double" minval="" maxval="">
+					0.150000
+				</Var>
+				<Var name="Goal width" type="double" minval="" maxval="">
+					0.400000
+				</Var>
+				<Var name="Goal height" type="double" minval="" maxval="">
+					0.050000
+				</Var>
+			</Var>
+			<Var name="VSSS B" type="list">
+				<Var name="Line Thickness" type="double" minval="" maxval="">
+					0.003000
+				</Var>
+				<Var name="Length" type="double" minval="" maxval="">
+					1.500000
+				</Var>
+				<Var name="Width" type="double" minval="" maxval="">
+					1.300000
+				</Var>
+				<Var name="Radius" type="double" minval="" maxval="">
+					0.200000
+				</Var>
+				<Var name="Free Kick Distance From Defense Area" type="double" minval="" maxval="">
+					0.200000
+				</Var>
+				<Var name="Penalty width" type="double" minval="" maxval="">
+					0.700000
+				</Var>
+				<Var name="Penalty depth" type="double" minval="" maxval="">
+					0.150000
+				</Var>
+				<Var name="Penalty point" type="double" minval="" maxval="">
+					0.375000
+				</Var>
+				<Var name="Margin" type="double" minval="" maxval="">
+					0.300000
+				</Var>
+				<Var name="Referee margin" type="double" minval="" maxval="">
+					0.400000
+				</Var>
+				<Var name="Wall thickness" type="double" minval="" maxval="">
+					0.025000
+				</Var>
+				<Var name="Goal thickness" type="double" minval="" maxval="">
+					0.025000
+				</Var>
+				<Var name="Goal depth" type="double" minval="" maxval="">
+					0.100000
+				</Var>
+				<Var name="Goal width" type="double" minval="" maxval="">
+					0.400000
+				</Var>
+				<Var name="Goal height" type="double" minval="" maxval="">
+					0.050000
+				</Var>
+			</Var>
+		</Var>
+		<Var name="Ball" type="list">
+			<Var name="Radius" type="double" minval="" maxval="">
+				0.021500
+			</Var>
+		</Var>
+		<Var name="Blue Team" type="stringenum">
+			Parsian
+			<Var name="0" type="string">
+				Parsian
+			</Var>
+			<Var name="1" type="string">
+				ParsianNew
+			</Var>
+			<Var name="2" type="string">
+				RoboIME2012
+			</Var>
+			<Var name="3" type="string">
+				Parsian
+			</Var>
+			<Var name="4" type="string">
+				ParsianNew
+			</Var>
+			<Var name="5" type="string">
+				RoboIME2012
+			</Var>
+		</Var>
+		<Var name="Yellow Team" type="stringenum">
+			Parsian
+			<Var name="0" type="string">
+				Parsian
+			</Var>
+			<Var name="1" type="string">
+				ParsianNew
+			</Var>
+			<Var name="2" type="string">
+				RoboIME2012
+			</Var>
+			<Var name="3" type="string">
+				Parsian
+			</Var>
+			<Var name="4" type="string">
+				ParsianNew
+			</Var>
+			<Var name="5" type="string">
+				RoboIME2012
+			</Var>
+		</Var>
+	</Var>
+	<Var name="Physics" type="list">
+		<Var name="World" type="list">
+			<Var name="Desired FPS" type="double" minval="" maxval="">
+				60.000000
+			</Var>
+			<Var name="Synchronize ODE with OpenGL" type="bool">
+				false
+			</Var>
+			<Var name="Synchronize SimStep with python " type="bool">
+				false
+			</Var>
+			<Var name="ODE time step" type="double" minval="" maxval="">
+				0.016000
+			</Var>
+			<Var name="Gravity" type="double" minval="" maxval="">
+				9.800000
+			</Var>
+			<Var name="Auto reset turn-over" type="bool">
+				true
+			</Var>
+		</Var>
+		<Var name="Ball" type="list">
+			<Var name="Ball mass" type="double" minval="" maxval="">
+				0.043000
+			</Var>
+			<Var name="Ball-ground friction" type="double" minval="" maxval="">
+				0.060000
+			</Var>
+			<Var name="Ball-ground slip" type="double" minval="" maxval="">
+				0.090000
+			</Var>
+			<Var name="Ball-ground bounce factor" type="double" minval="" maxval="">
+				0.500000
+			</Var>
+			<Var name="Ball-ground bounce min velocity" type="double" minval="" maxval="">
+				0.010000
+			</Var>
+			<Var name="Ball linear damping" type="double" minval="" maxval="">
+				0.004000
+			</Var>
+			<Var name="Ball angular damping" type="double" minval="" maxval="">
+				0.004000
+			</Var>
+		</Var>
+	</Var>
+	<Var name="Communication" type="list">
+		<Var name="Vision multicast address" type="string">
+			224.0.0.1
+		</Var>
+		<Var name="Vision multicast port" type="int" minval="" maxval="">
+			10002
+		</Var>
+		<Var name="Command listen port" type="int" minval="" maxval="">
+			20011
+		</Var>
+		<Var name="Blue Team status send port" type="int" minval="" maxval="">
+			30011
+		</Var>
+		<Var name="Yellow Team status send port" type="int" minval="" maxval="">
+			30012
+		</Var>
+		<Var name="Sending delay (milliseconds)" type="int" minval="" maxval="">
+			0
+		</Var>
+		<Var name="Send geometry every X frames" type="int" minval="" maxval="">
+			120
+		</Var>
+		<Var name="Gaussian noise" type="list">
+			<Var name="Noise" type="bool">
+				false
+			</Var>
+			<Var name="Deviation for x values" type="double" minval="" maxval="">
+				3.000000
+			</Var>
+			<Var name="Deviation for y values" type="double" minval="" maxval="">
+				3.000000
+			</Var>
+			<Var name="Deviation for angle values" type="double" minval="" maxval="">
+				2.000000
+			</Var>
+			<Var name="Vanishing" type="bool">
+				false
+			</Var>
+		</Var>
+		<Var name="Vanishing probability" type="list">
+			<Var name="Blue team" type="double" minval="" maxval="">
+				0.000000
+			</Var>
+			<Var name="Yellow team" type="double" minval="" maxval="">
+				0.000000
+			</Var>
+			<Var name="Ball" type="double" minval="" maxval="">
+				0.000000
+			</Var>
+		</Var>
+	</Var>
+</VarXML>

--- a/src/configwidget.cpp
+++ b/src/configwidget.cpp
@@ -216,22 +216,49 @@ void ConfigWidget::loadRobotsSettings()
 
 void ConfigWidget::loadRobotSettings(const QString&& team)
 {
-    QString ss = qApp->applicationDirPath()+QString("/../config/")+QString("%1.ini").arg(team);
-    robot_settings = new QSettings(ss, QSettings::IniFormat);
-    robotSettings.RobotCenterFromKicker = robot_settings->value("Geometery/CenterFromKicker", 0.073).toDouble();
-    robotSettings.RobotRadius = robot_settings->value("Geometery/Radius", 0.09).toDouble();
-    robotSettings.RobotHeight = robot_settings->value("Geometery/Height", 0.13).toDouble();
-    robotSettings.BottomHeight = robot_settings->value("Geometery/RobotBottomZValue", 0.02).toDouble();
-    robotSettings.WheelRadius = robot_settings->value("Geometery/WheelRadius", 0.0325).toDouble();
-    robotSettings.WheelThickness = robot_settings->value("Geometery/WheelThickness", 0.005).toDouble();
-    robotSettings.Wheel1Angle = robot_settings->value("Geometery/Wheel1Angle", 60).toDouble();
-    robotSettings.Wheel2Angle = robot_settings->value("Geometery/Wheel2Angle", 135).toDouble();
-    robotSettings.BallRadius = robot_settings->value("Geometery/BallRadius", 0.002).toDouble();
-    robotSettings.BallMass = robot_settings->value("Geometery/BallMass", 0.001).toDouble();
+    const QString iniName = QString("%1.ini").arg(team);
+    QStringList candidates;
 
-    robotSettings.BodyMass  = robot_settings->value("Physics/BodyMass", 2).toDouble();
-    robotSettings.WheelMass = robot_settings->value("Physics/WheelMass", 0.2).toDouble();
-    robotSettings.WheelTangentFriction = robot_settings->value("Physics/WheelTangentFriction", 0.8f).toDouble();
-    robotSettings.WheelPerpendicularFriction = robot_settings->value("Physics/WheelPerpendicularFriction", 0.05f).toDouble();
-    robotSettings.Wheel_Motor_FMax = robot_settings->value("Physics/WheelMotorMaximumApplyingTorque", 0.2f).toDouble();
+    candidates << (qApp->applicationDirPath() + "/../config/" + iniName);
+    candidates << (qApp->applicationDirPath() + "/../share/grsim/config/" + iniName);
+    candidates << (QString("/usr/local/share/grsim/config/") + iniName);
+    candidates << (QString("/usr/local/config/") + iniName);
+    candidates << (qApp->applicationDirPath() + "/config/" + iniName);
+    candidates << (QDir::homePath() + "/.grsim/config/" + iniName);
+
+    QString ss;
+    for (const auto& p : candidates) {
+        if (QFileInfo::exists(p)) {
+            ss = QDir::cleanPath(p);
+            break;
+        }
+    }
+
+    if (ss.isEmpty()) {
+        ss = qApp->applicationDirPath() + "/../config/" + iniName;
+        qWarning() << "[FIRASim] Could not find robot ini for team" << team
+                   << "Tried:" << candidates;
+    } else {
+        qDebug() << "[FIRASim] Using robot ini:" << ss;
+    }
+
+    delete robot_settings;
+    robot_settings = new QSettings(ss, QSettings::IniFormat);
+
+    robotSettings.RobotCenterFromKicker = robot_settings->value("Geometery/CenterFromKicker", 0.073).toDouble();
+    robotSettings.RobotRadius           = robot_settings->value("Geometery/Radius", 0.09).toDouble();
+    robotSettings.RobotHeight           = robot_settings->value("Geometery/Height", 0.13).toDouble();
+    robotSettings.BottomHeight          = robot_settings->value("Geometery/RobotBottomZValue", 0.02).toDouble();
+    robotSettings.WheelRadius           = robot_settings->value("Geometery/WheelRadius", 0.0325).toDouble();
+    robotSettings.WheelThickness        = robot_settings->value("Geometery/WheelThickness", 0.005).toDouble();
+    robotSettings.Wheel1Angle           = robot_settings->value("Geometery/Wheel1Angle", 60).toDouble();
+    robotSettings.Wheel2Angle           = robot_settings->value("Geometery/Wheel2Angle", 135).toDouble();
+    robotSettings.BallRadius            = robot_settings->value("Geometery/BallRadius", 0.002).toDouble();
+    robotSettings.BallMass              = robot_settings->value("Geometery/BallMass", 0.001).toDouble();
+
+    robotSettings.BodyMass              = robot_settings->value("Physics/BodyMass", 2).toDouble();
+    robotSettings.WheelMass             = robot_settings->value("Physics/WheelMass", 0.2).toDouble();
+    robotSettings.WheelTangentFriction  = robot_settings->value("Physics/WheelTangentFriction", 0.8).toDouble();
+    robotSettings.WheelPerpendicularFriction = robot_settings->value("Physics/WheelPerpendicularFriction", 0.05).toDouble();
+    robotSettings.Wheel_Motor_FMax      = robot_settings->value("Physics/WheelMotorMaximumApplyingTorque", 0.2).toDouble();
 }


### PR DESCRIPTION
## 🐛 Bugfix: FIRASim Docker loads correct robot geometry/configs

### What was the problem?
When running FIRASim inside Docker, robot geometry was loaded with fallback defaults (e.g. radius/height),
causing robots to appear **giant** compared to native builds.

Root cause: installed binary runs from `/usr/local/bin`, so `qApp->applicationDirPath()` changes and the app
may not find team `.ini` files (e.g. `Parsian.ini`) and/or the `~/.grsim.xml` file. This triggers default
values in `loadRobotSettings()`.

### What changed?
- Ship a default XML template (`firasim.xml`) inside the image and copy it to `~/.grsim.xml` on first run.
- Ensure team configuration `.ini` files are available in the installed path expected by the app
  (e.g. `/usr/local/share/grsim/config`).
- Docker entrypoint updated to initialize runtime config and support X11/VNC/offscreen modes.

### How to test
#### X11 (host display)
```bash
xhost +local:docker
docker run --rm -it \
  -e DISPLAY=$DISPLAY \
  -v /tmp/.X11-unix:/tmp/.X11-unix \
  --device /dev/dri \
  taurabots/firasim:latest
